### PR TITLE
[Feat] plant history

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -8,6 +8,7 @@ plugins {
     kotlin("plugin.spring") version "1.9.21"
     kotlin("plugin.jpa") version "1.9.21"
     kotlin("plugin.allopen") version "1.9.21"
+    kotlin("plugin.noarg") version "1.9.21"
 }
 
 group = "gdsc"
@@ -17,6 +18,12 @@ allOpen {
     annotation("jakarta.persistence.Entity")
     annotation("jakarta.persistence.Embeddable")
     annotation("jakarta.persistence.MappedSuperclass")
+}
+
+noArg {
+    annotation("javax.persistence.Entity")
+    annotation("javax.persistence.MappedSuperclass")
+    annotation("javax.persistence.Embeddable")
 }
 
 java {

--- a/src/main/kotlin/gdsc/plantory/common/exception/dto/ErrorDtos.kt
+++ b/src/main/kotlin/gdsc/plantory/common/exception/dto/ErrorDtos.kt
@@ -9,3 +9,5 @@ open class PlantoryException(override val message: String, val status: Int) : Ru
 class NotFoundException(message: String = "존재하지 않는 요청입니다.") : PlantoryException(message, HttpStatus.NOT_FOUND.value())
 
 class ConflictException(message: String = "이미 등록된 디바이스 입니다.") : PlantoryException(message, HttpStatus.CONFLICT.value())
+
+class BadRequestException(message: String = "잘못된 요청입니다.") : PlantoryException(message, HttpStatus.BAD_REQUEST.value())

--- a/src/main/kotlin/gdsc/plantory/plant/domain/CompanionPlant.kt
+++ b/src/main/kotlin/gdsc/plantory/plant/domain/CompanionPlant.kt
@@ -88,7 +88,7 @@ class CompanionPlant(
         get() = this.waterCycle
 
     val getBirthDate: LocalDate
-        get() = LocalDate.from(this.birthDate ?: this.createAt!!.toLocalDate())
+        get() = LocalDate.from(this.birthDate ?: this.createAt)
 
     fun saveRecord(comment: String, imageUrl: String? = null) =
         this.records.add(PlantRecord(imageUrl, comment, this))

--- a/src/main/kotlin/gdsc/plantory/plant/domain/CompanionPlant.kt
+++ b/src/main/kotlin/gdsc/plantory/plant/domain/CompanionPlant.kt
@@ -93,17 +93,17 @@ class CompanionPlant(
     fun saveRecord(comment: String, imageUrl: String? = null) =
         this.records.add(PlantRecord(imageUrl, comment, this))
 
-    fun saveHistory(waterChange: HistoryType, date: LocalDate = LocalDate.now()) {
+    fun saveHistory(historyType: HistoryType, date: LocalDate = LocalDate.now()) {
         if (isNotCurrentDay(date)) {
             throw IllegalArgumentException("물을 줄 날짜는 오늘 날짜여야 합니다.")
         }
 
-        if (waterChange == HistoryType.WATER_CHANGE) {
+        if (historyType == HistoryType.WATER_CHANGE) {
             this.lastWaterDate = date
             this.nextWaterDate = date.plusDays(this.waterCycle.toLong())
         }
 
-        this.histories.add(History(waterChange, date, this))
+        this.histories.add(History(historyType, date, this))
     }
 
     fun recordSize(): Int = this.records.size()

--- a/src/main/kotlin/gdsc/plantory/plant/domain/CompanionPlantRepository.kt
+++ b/src/main/kotlin/gdsc/plantory/plant/domain/CompanionPlantRepository.kt
@@ -8,6 +8,14 @@ fun CompanionPlantRepository.findByIdAndMemberIdOrThrow(id: Long, memberId: Long
 }
 
 interface CompanionPlantRepository : JpaRepository<CompanionPlant, Long> {
+
+    //    @Query("""
+//        SELECT new gdsc.plantory.plant.common.dto.CompanionPlantDto(
+//            c.id, c.imageUrl._value, c.nickname._value, c.shortDescription._value, c.birthDate)
+//        FROM CompanionPlant c
+//        WHERE c.memberId = :memberId
+//    """)
+//    fun findAllPlantDtoByMemberId(memberId: Long): List<CompanionPlantDto>
     fun findAllByMemberId(memberId: Long): List<CompanionPlant>
     fun findByIdAndMemberId(id: Long, memberId: Long): CompanionPlant?
 }

--- a/src/main/kotlin/gdsc/plantory/plant/domain/CompanionPlantRepository.kt
+++ b/src/main/kotlin/gdsc/plantory/plant/domain/CompanionPlantRepository.kt
@@ -1,7 +1,13 @@
 package gdsc.plantory.plant.domain
 
+import NotFoundException
 import org.springframework.data.jpa.repository.JpaRepository
+
+fun CompanionPlantRepository.findByIdAndMemberIdOrThrow(id: Long, memberId: Long): CompanionPlant {
+    return findByIdAndMemberId(id, memberId) ?: throw NotFoundException("식물 정보가 없어요")
+}
 
 interface CompanionPlantRepository : JpaRepository<CompanionPlant, Long> {
     fun findAllByMemberId(memberId: Long): List<CompanionPlant>
+    fun findByIdAndMemberId(id: Long, memberId: Long): CompanionPlant?
 }

--- a/src/main/kotlin/gdsc/plantory/plant/domain/History.kt
+++ b/src/main/kotlin/gdsc/plantory/plant/domain/History.kt
@@ -6,6 +6,7 @@ import jakarta.persistence.Column
 import jakarta.persistence.Entity
 import jakarta.persistence.EnumType
 import jakarta.persistence.Enumerated
+import jakarta.persistence.FetchType
 import jakarta.persistence.GeneratedValue
 import jakarta.persistence.GenerationType
 import jakarta.persistence.Id
@@ -25,7 +26,7 @@ class History(
     @Column(name = "history_date", nullable = false)
     private val date: LocalDate,
 
-    @ManyToOne(cascade = [CascadeType.PERSIST])
+    @ManyToOne(cascade = [CascadeType.PERSIST], fetch = FetchType.LAZY)
     @JoinColumn(name = "companion_plant_id")
     private val companionPlant: CompanionPlant? = null,
 

--- a/src/main/kotlin/gdsc/plantory/plant/domain/HistoryType.kt
+++ b/src/main/kotlin/gdsc/plantory/plant/domain/HistoryType.kt
@@ -1,5 +1,11 @@
 package gdsc.plantory.plant.domain
 
 enum class HistoryType {
-    WATER_CHANGE, POT_CHANGE, RECORDING
+    WATER_CHANGE, POT_CHANGE, RECORDING;
+
+    companion object {
+        fun byNameIgnoreCaseOrNull(input: String): HistoryType? {
+            return entries.firstOrNull { it.name.equals(input, true) }
+        }
+    }
 }

--- a/src/main/kotlin/gdsc/plantory/plant/domain/PlantRecord.kt
+++ b/src/main/kotlin/gdsc/plantory/plant/domain/PlantRecord.kt
@@ -5,6 +5,7 @@ import jakarta.persistence.CascadeType
 import jakarta.persistence.Column
 import jakarta.persistence.Embedded
 import jakarta.persistence.Entity
+import jakarta.persistence.FetchType
 import jakarta.persistence.GeneratedValue
 import jakarta.persistence.GenerationType
 import jakarta.persistence.Id
@@ -20,7 +21,7 @@ class PlantRecord(
 
     _comment: String,
 
-    @ManyToOne(cascade = [CascadeType.PERSIST])
+    @ManyToOne(cascade = [CascadeType.PERSIST], fetch = FetchType.LAZY)
     @JoinColumn(name = "companion_plant_id")
     private val companionPlant: CompanionPlant? = null,
 

--- a/src/main/kotlin/gdsc/plantory/plant/presentation/PlantCommandApi.kt
+++ b/src/main/kotlin/gdsc/plantory/plant/presentation/PlantCommandApi.kt
@@ -1,11 +1,15 @@
 package gdsc.plantory.plant.presentation
 
+import BadRequestException
 import gdsc.plantory.common.support.AccessDeviceToken
+import gdsc.plantory.plant.domain.HistoryType
 import gdsc.plantory.plant.presentation.dto.CompanionPlantCreateRequest
+import gdsc.plantory.plant.presentation.dto.CompanionPlantHistoryRequest
 import gdsc.plantory.plant.service.PlantService
 import org.springframework.http.MediaType
 import org.springframework.http.ResponseEntity
 import org.springframework.web.bind.annotation.PostMapping
+import org.springframework.web.bind.annotation.RequestBody
 import org.springframework.web.bind.annotation.RequestMapping
 import org.springframework.web.bind.annotation.RequestPart
 import org.springframework.web.bind.annotation.RestController
@@ -24,6 +28,18 @@ class PlantCommandApi(
         @AccessDeviceToken deviceToken: String,
     ): ResponseEntity<Unit> {
         plantService.create(request, image, deviceToken)
+        return ResponseEntity.ok().build()
+    }
+
+    @PostMapping("/histories", consumes = [MediaType.APPLICATION_JSON_VALUE])
+    fun createHistory(
+        @RequestBody request: CompanionPlantHistoryRequest,
+        @AccessDeviceToken deviceToken: String,
+    ): ResponseEntity<Unit> {
+        val historyType = HistoryType.byNameIgnoreCaseOrNull(request.historyType)
+            ?: throw BadRequestException("잘못된 히스토리 타입입니다.")
+
+        plantService.createHistory(request.companionPlantId, deviceToken, historyType);
         return ResponseEntity.ok().build()
     }
 }

--- a/src/main/kotlin/gdsc/plantory/plant/presentation/PlantQueryApi.kt
+++ b/src/main/kotlin/gdsc/plantory/plant/presentation/PlantQueryApi.kt
@@ -1,7 +1,7 @@
 package gdsc.plantory.plant.presentation
 
 import gdsc.plantory.common.support.AccessDeviceToken
-import gdsc.plantory.plant.presentation.dto.CompanionPlantResponse
+import gdsc.plantory.plant.presentation.dto.CompanionPlantsLookupResponse
 import gdsc.plantory.plant.service.PlantService
 import org.springframework.http.ResponseEntity
 import org.springframework.web.bind.annotation.GetMapping
@@ -14,17 +14,11 @@ class PlantQueryApi(
     private val plantService: PlantService
 ) {
 
-    @GetMapping()
-    fun lookup(@AccessDeviceToken deviceToken: String): ResponseEntity<List<CompanionPlantResponse>> {
-        val companionPlants = plantService.lookup(deviceToken)
-        return ResponseEntity.ok().body(companionPlants.map {
-            CompanionPlantResponse(
-                it.getId,
-                it.getImageUrl,
-                it.getNickName,
-                it.getSortDescription,
-                it.getBirthDate
-            )
-        })
+    @GetMapping
+    fun lookupAllPlantsOfMember(
+        @AccessDeviceToken deviceToken: String
+    ): ResponseEntity<CompanionPlantsLookupResponse> {
+        val companionPlants = plantService.lookupAllPlantsOfMember(deviceToken)
+        return ResponseEntity.ok().body(CompanionPlantsLookupResponse(companionPlants))
     }
 }

--- a/src/main/kotlin/gdsc/plantory/plant/presentation/dto/CompanionPlantDto.kt
+++ b/src/main/kotlin/gdsc/plantory/plant/presentation/dto/CompanionPlantDto.kt
@@ -1,0 +1,22 @@
+package gdsc.plantory.plant.presentation.dto
+
+import gdsc.plantory.plant.domain.CompanionPlant
+import java.time.LocalDate
+
+data class CompanionPlantDto(
+    val id: Long,
+    val imageUrl: String,
+    val nickname: String,
+    val shortDescription: String,
+    val birthDate: LocalDate,
+) {
+    companion object {
+        fun from(plant: CompanionPlant): CompanionPlantDto = CompanionPlantDto(
+            id = plant.getId,
+            imageUrl = plant.getImageUrl,
+            nickname = plant.getNickName,
+            shortDescription = plant.getSortDescription,
+            birthDate = plant.getBirthDate
+        )
+    }
+}

--- a/src/main/kotlin/gdsc/plantory/plant/presentation/dto/CompanionPlantHistoryRequest.kt
+++ b/src/main/kotlin/gdsc/plantory/plant/presentation/dto/CompanionPlantHistoryRequest.kt
@@ -1,0 +1,8 @@
+package gdsc.plantory.plant.presentation.dto
+
+import jakarta.validation.constraints.NotBlank
+
+data class CompanionPlantHistoryRequest(
+    @NotBlank val companionPlantId: Long,
+    @NotBlank val historyType: String,
+)

--- a/src/main/kotlin/gdsc/plantory/plant/presentation/dto/CompanionPlantsLookupResponse.kt
+++ b/src/main/kotlin/gdsc/plantory/plant/presentation/dto/CompanionPlantsLookupResponse.kt
@@ -1,0 +1,5 @@
+package gdsc.plantory.plant.presentation.dto
+
+data class CompanionPlantsLookupResponse(
+    val companionPlants: List<CompanionPlantDto>
+)

--- a/src/main/kotlin/gdsc/plantory/plant/service/PlantService.kt
+++ b/src/main/kotlin/gdsc/plantory/plant/service/PlantService.kt
@@ -3,11 +3,11 @@ package gdsc.plantory.plant.service
 import gdsc.plantory.common.support.photo.PhotoLocalManager
 import gdsc.plantory.member.domain.MemberRepository
 import gdsc.plantory.member.domain.findByDeviceTokenOrThrow
-import gdsc.plantory.plant.domain.CompanionPlant
 import gdsc.plantory.plant.domain.CompanionPlantRepository
 import gdsc.plantory.plant.domain.HistoryType
 import gdsc.plantory.plant.domain.findByIdAndMemberIdOrThrow
 import gdsc.plantory.plant.presentation.dto.CompanionPlantCreateRequest
+import gdsc.plantory.plant.presentation.dto.CompanionPlantDto
 import gdsc.plantory.plantInformation.domain.PlantInformationRepository
 import gdsc.plantory.plantInformation.domain.findByIdOrThrow
 import org.springframework.stereotype.Service
@@ -33,16 +33,20 @@ class PlantService(
         companionPlantRepository.save(companionPlant)
     }
 
-    @Transactional(readOnly = true)
-    fun lookup(deviceToken: String): List<CompanionPlant> {
-        val findMember = memberRepository.findByDeviceTokenOrThrow(deviceToken)
-        return companionPlantRepository.findAllByMemberId(findMember.getId)
-    }
-
     fun createHistory(plantId: Long, deviceToken: String, historyType: HistoryType) {
         val findMember = memberRepository.findByDeviceTokenOrThrow(deviceToken)
         val findPlant = companionPlantRepository.findByIdAndMemberIdOrThrow(plantId, findMember.getId)
         findPlant.saveHistory(historyType)
+    }
+
+    @Transactional(readOnly = true)
+    fun lookupAllPlantsOfMember(deviceToken: String): List<CompanionPlantDto> {
+        val findMember = memberRepository.findByDeviceTokenOrThrow(deviceToken)
+
+        return companionPlantRepository.findAllByMemberId(findMember.getId)
+            .stream()
+            .map { CompanionPlantDto.from(it) }
+            .toList()
     }
 
     private fun saveImageAndGetPath(image: MultipartFile?, defaultUrl: String): String {

--- a/src/main/kotlin/gdsc/plantory/plant/service/PlantService.kt
+++ b/src/main/kotlin/gdsc/plantory/plant/service/PlantService.kt
@@ -5,6 +5,8 @@ import gdsc.plantory.member.domain.MemberRepository
 import gdsc.plantory.member.domain.findByDeviceTokenOrThrow
 import gdsc.plantory.plant.domain.CompanionPlant
 import gdsc.plantory.plant.domain.CompanionPlantRepository
+import gdsc.plantory.plant.domain.HistoryType
+import gdsc.plantory.plant.domain.findByIdAndMemberIdOrThrow
 import gdsc.plantory.plant.presentation.dto.CompanionPlantCreateRequest
 import gdsc.plantory.plantInformation.domain.PlantInformationRepository
 import gdsc.plantory.plantInformation.domain.findByIdOrThrow
@@ -31,9 +33,16 @@ class PlantService(
         companionPlantRepository.save(companionPlant)
     }
 
+    @Transactional(readOnly = true)
     fun lookup(deviceToken: String): List<CompanionPlant> {
         val findMember = memberRepository.findByDeviceTokenOrThrow(deviceToken)
         return companionPlantRepository.findAllByMemberId(findMember.getId)
+    }
+
+    fun createHistory(plantId: Long, deviceToken: String, historyType: HistoryType) {
+        val findMember = memberRepository.findByDeviceTokenOrThrow(deviceToken)
+        val findPlant = companionPlantRepository.findByIdAndMemberIdOrThrow(plantId, findMember.getId)
+        findPlant.saveHistory(historyType)
     }
 
     private fun saveImageAndGetPath(image: MultipartFile?, defaultUrl: String): String {

--- a/src/main/kotlin/gdsc/plantory/plantInformation/domain/PlantInformation.kt
+++ b/src/main/kotlin/gdsc/plantory/plantInformation/domain/PlantInformation.kt
@@ -67,6 +67,9 @@ class PlantInformation(
         _waterCycleSpring, _waterCycleSummer, _waterCycleAutumn, _waterCycleWinter
     )
 
+    val getId: Long
+        get() = this.id
+
     val getImageUrl: String
         get() = this.imageUrl.value
 

--- a/src/test/kotlin/gdsc/plantory/acceptance/CompanionPlantAcceptanceTest.kt
+++ b/src/test/kotlin/gdsc/plantory/acceptance/CompanionPlantAcceptanceTest.kt
@@ -1,10 +1,13 @@
 package gdsc.plantory.acceptance
 
+import gdsc.plantory.acceptance.CommonStep.Companion.응답_확인
 import gdsc.plantory.acceptance.CompanionPlantStep.Companion.반려_식물_등록_요청
 import gdsc.plantory.acceptance.CompanionPlantStep.Companion.반려_식물_조회_요청
+import gdsc.plantory.acceptance.CompanionPlantStep.Companion.반려_식물_히스토리_생성_요청
 import gdsc.plantory.acceptance.MemberStep.Companion.회원_가입_요청
 import gdsc.plantory.fixture.CompanionPlantFixture
 import gdsc.plantory.member.dto.MemberSignUpRequest
+import gdsc.plantory.plant.presentation.dto.CompanionPlantHistoryRequest
 import gdsc.plantory.util.AcceptanceTest
 import org.junit.jupiter.api.DisplayName
 import org.junit.jupiter.api.Test
@@ -22,7 +25,19 @@ class CompanionPlantAcceptanceTest : AcceptanceTest() {
         val 식물_등록_요청_응답 = 반려_식물_등록_요청(createRequest, "device_id")
 
         // then
-        CommonStep.응답_확인(식물_등록_요청_응답, HttpStatus.OK)
+        응답_확인(식물_등록_요청_응답, HttpStatus.OK)
+    }
+
+    @Test
+    fun `반려식물 물주기 히스토리 등록`() {
+        // given
+        val 물줌_기록 = CompanionPlantHistoryRequest(1L, "WATER_CHANGE")
+
+        // when
+        val 식물_히스토리_생성_응답 = 반려_식물_히스토리_생성_요청(물줌_기록, "device_id")
+
+        // then
+        응답_확인(식물_히스토리_생성_응답, HttpStatus.OK)
     }
 
     @Test
@@ -34,6 +49,6 @@ class CompanionPlantAcceptanceTest : AcceptanceTest() {
         val 식물_조회_요청_응답 = 반려_식물_조회_요청("device-token")
 
         // then
-        CommonStep.응답_확인(식물_조회_요청_응답, HttpStatus.OK)
+        응답_확인(식물_조회_요청_응답, HttpStatus.OK)
     }
 }

--- a/src/test/kotlin/gdsc/plantory/acceptance/CompanionPlantAcceptanceTest.kt
+++ b/src/test/kotlin/gdsc/plantory/acceptance/CompanionPlantAcceptanceTest.kt
@@ -4,6 +4,7 @@ import gdsc.plantory.acceptance.CommonStep.Companion.응답_확인
 import gdsc.plantory.acceptance.CompanionPlantStep.Companion.반려_식물_등록_요청
 import gdsc.plantory.acceptance.CompanionPlantStep.Companion.반려_식물_조회_요청
 import gdsc.plantory.acceptance.CompanionPlantStep.Companion.반려_식물_히스토리_생성_요청
+import gdsc.plantory.acceptance.CompanionPlantStep.Companion.조회_응답_확인
 import gdsc.plantory.acceptance.MemberStep.Companion.회원_가입_요청
 import gdsc.plantory.fixture.CompanionPlantFixture
 import gdsc.plantory.member.dto.MemberSignUpRequest
@@ -22,7 +23,7 @@ class CompanionPlantAcceptanceTest : AcceptanceTest() {
         val createRequest = CompanionPlantFixture.generatePetPlantCreateRequest(1L)
 
         // when
-        val 식물_등록_요청_응답 = 반려_식물_등록_요청(createRequest, "device_id")
+        val 식물_등록_요청_응답 = 반려_식물_등록_요청(createRequest, "device-token")
 
         // then
         응답_확인(식물_등록_요청_응답, HttpStatus.OK)
@@ -34,7 +35,7 @@ class CompanionPlantAcceptanceTest : AcceptanceTest() {
         val 물줌_기록 = CompanionPlantHistoryRequest(1L, "WATER_CHANGE")
 
         // when
-        val 식물_히스토리_생성_응답 = 반려_식물_히스토리_생성_요청(물줌_기록, "device_id")
+        val 식물_히스토리_생성_응답 = 반려_식물_히스토리_생성_요청(물줌_기록, "device-token")
 
         // then
         응답_확인(식물_히스토리_생성_응답, HttpStatus.OK)
@@ -49,6 +50,6 @@ class CompanionPlantAcceptanceTest : AcceptanceTest() {
         val 식물_조회_요청_응답 = 반려_식물_조회_요청("device-token")
 
         // then
-        응답_확인(식물_조회_요청_응답, HttpStatus.OK)
+        조회_응답_확인(식물_조회_요청_응답)
     }
 }

--- a/src/test/kotlin/gdsc/plantory/acceptance/CompanionPlantStep.kt
+++ b/src/test/kotlin/gdsc/plantory/acceptance/CompanionPlantStep.kt
@@ -8,6 +8,8 @@ import io.restassured.mapper.ObjectMapperType
 import io.restassured.response.ExtractableResponse
 import io.restassured.response.Response
 import io.restassured.specification.MultiPartSpecification
+import org.assertj.core.api.Assertions
+import org.junit.jupiter.api.assertAll
 import org.springframework.http.HttpStatus
 import org.springframework.http.MediaType
 
@@ -49,6 +51,20 @@ class CompanionPlantStep {
                 .log().all()
                 .extract()
 
+        fun 조회_응답_확인(식물_조회_요청_응답: ExtractableResponse<Response>) {
+            assertAll(
+                { Assertions.assertThat(식물_조회_요청_응답.statusCode()).isEqualTo(HttpStatus.OK.value()) },
+                { Assertions.assertThat(식물_조회_요청_응답.jsonPath().getString("companionPlants.id")).isNotBlank() },
+                { Assertions.assertThat(식물_조회_요청_응답.jsonPath().getString("companionPlants.imageUrl")).isNotBlank() },
+                { Assertions.assertThat(식물_조회_요청_응답.jsonPath().getString("companionPlants.nickname")).isNotBlank() },
+                {
+                    Assertions.assertThat(식물_조회_요청_응답.jsonPath().getString("companionPlants.shortDescription"))
+                        .isNotBlank()
+                },
+                { Assertions.assertThat(식물_조회_요청_응답.jsonPath().getString("companionPlants.birthDate")).isNotBlank() },
+            )
+        }
+
         fun 반려_식물_조회_요청(
             deviceToken: String,
         ): ExtractableResponse<Response> {
@@ -60,7 +76,6 @@ class CompanionPlantStep {
                 .get("/api/v1/plants")
                 .then()
                 .log().all()
-                .statusCode(HttpStatus.OK.value())
                 .extract()
         }
 

--- a/src/test/kotlin/gdsc/plantory/acceptance/CompanionPlantStep.kt
+++ b/src/test/kotlin/gdsc/plantory/acceptance/CompanionPlantStep.kt
@@ -1,6 +1,7 @@
 package gdsc.plantory.acceptance
 
 import gdsc.plantory.plant.presentation.dto.CompanionPlantCreateRequest
+import gdsc.plantory.plant.presentation.dto.CompanionPlantHistoryRequest
 import io.restassured.RestAssured
 import io.restassured.builder.MultiPartSpecBuilder
 import io.restassured.mapper.ObjectMapperType
@@ -32,6 +33,21 @@ class CompanionPlantStep {
                 .statusCode(HttpStatus.OK.value())
                 .extract()
         }
+
+        fun 반려_식물_히스토리_생성_요청(
+            request: CompanionPlantHistoryRequest,
+            deviceToken: String,
+        ): ExtractableResponse<Response> =
+            RestAssured
+                .given()
+                .contentType(MediaType.APPLICATION_JSON_VALUE)
+                .header("Device-Token", deviceToken)
+                .log().all()
+                .body(request)
+                .`when`().post("/api/v1/plants/histories")
+                .then()
+                .log().all()
+                .extract()
 
         fun 반려_식물_조회_요청(
             deviceToken: String,

--- a/src/test/kotlin/gdsc/plantory/acceptance/MemberAcceptanceTest.kt
+++ b/src/test/kotlin/gdsc/plantory/acceptance/MemberAcceptanceTest.kt
@@ -15,7 +15,7 @@ class MemberAcceptanceTest : AcceptanceTest() {
     @Test
     fun `회원 가입`() {
         // given
-        val 회원_가입_정보 = MemberSignUpRequest("device-token")
+        val 회원_가입_정보 = MemberSignUpRequest("new-device-token")
 
         // when
         val 회원_가입_응답 = 회원_가입_요청(회원_가입_정보)

--- a/src/test/kotlin/gdsc/plantory/fixture/CompanionPlantFixture.kt
+++ b/src/test/kotlin/gdsc/plantory/fixture/CompanionPlantFixture.kt
@@ -1,9 +1,22 @@
 package gdsc.plantory.fixture
 
+import gdsc.plantory.plant.domain.CompanionPlant
 import gdsc.plantory.plant.presentation.dto.CompanionPlantCreateRequest
 import java.time.LocalDate
 
 object CompanionPlantFixture {
+
+    var 덕구리난: CompanionPlant = CompanionPlant(
+        _imageUrl = "https://nongsaro.go.kr/cms_contents/301/13336_MF_ATTACH_05.jpg",
+        _shortDescription = "덕구리난은 덕구리난과!",
+        _nickname = "shine",
+        birthDate = LocalDate.of(2024, 1, 1),
+        nextWaterDate = LocalDate.of(2024, 1, 10),
+        lastWaterDate = LocalDate.of(2024, 1, 7),
+        waterCycle = 3,
+        plantInformationId = 1L,
+        memberId = 1L,
+    )
 
     fun generatePetPlantCreateRequest(plantInformationId: Long): CompanionPlantCreateRequest {
         return CompanionPlantCreateRequest(

--- a/src/test/kotlin/gdsc/plantory/plant/domain/HistoryTypeTest.kt
+++ b/src/test/kotlin/gdsc/plantory/plant/domain/HistoryTypeTest.kt
@@ -1,0 +1,36 @@
+package gdsc.plantory.plant.domain
+
+import org.assertj.core.api.Assertions.assertThat
+import org.junit.jupiter.params.ParameterizedTest
+import org.junit.jupiter.params.provider.Arguments
+import org.junit.jupiter.params.provider.MethodSource
+import java.util.stream.Stream
+
+class HistoryTypeTest {
+
+    @ParameterizedTest
+    @MethodSource("historyTypeInputProvider")
+    fun `문자열로부터 Enum으로 변환`(input: String, historyType: HistoryType) {
+        // when
+        val result = HistoryType.byNameIgnoreCaseOrNull(input)
+
+        // then
+        assertThat(result).isEqualTo(historyType)
+    }
+
+
+    companion object {
+        @JvmStatic
+        private fun historyTypeInputProvider(): Stream<Arguments?>? {
+            return Stream.of<Arguments?>(
+                Arguments.of("WATER_CHANGE", HistoryType.WATER_CHANGE),
+                Arguments.of("water_change", HistoryType.WATER_CHANGE),
+                Arguments.of("POT_CHANGE", HistoryType.POT_CHANGE),
+                Arguments.of("pot_change", HistoryType.POT_CHANGE),
+                Arguments.of("RECORDING", HistoryType.RECORDING),
+                Arguments.of("recording", HistoryType.RECORDING)
+            )
+        }
+    }
+
+}

--- a/src/test/kotlin/gdsc/plantory/util/DatabaseLoader.kt
+++ b/src/test/kotlin/gdsc/plantory/util/DatabaseLoader.kt
@@ -2,18 +2,20 @@ package gdsc.plantory.util
 
 import gdsc.plantory.member.domain.Member
 import gdsc.plantory.member.domain.MemberRepository
+import gdsc.plantory.plant.domain.CompanionPlant
+import gdsc.plantory.plant.domain.CompanionPlantRepository
 import gdsc.plantory.plantInformation.domain.PlantInformation
 import gdsc.plantory.plantInformation.domain.PlantInformationRepository
 import org.slf4j.Logger
 import org.slf4j.LoggerFactory
 import org.springframework.stereotype.Component
-
-private const val DEFAULT_FOLDER_NAME = "default"
+import java.time.LocalDate
 
 @Component
 class DatabaseLoader(
     private val memberRepository: MemberRepository,
     private val plantInformationRepository: PlantInformationRepository,
+    private val companionPlantRepository: CompanionPlantRepository,
 ) {
 
     companion object {
@@ -25,7 +27,7 @@ class DatabaseLoader(
 
         memberRepository.save(Member("device_id"))
 
-        plantInformationRepository.save(
+        val plantInformation = plantInformationRepository.save(
             PlantInformation(
                 _species = "덕구리난",
                 _imageUrl = "https://nongsaro.go.kr/cms_contents/301/13336_MF_ATTACH_05.jpg",
@@ -43,6 +45,20 @@ class DatabaseLoader(
                 _waterCycleSummer = 3,
                 _waterCycleAutumn = 4,
                 _waterCycleWinter = 4,
+                id = 1L,
+            )
+        )
+
+        companionPlantRepository.save(
+            CompanionPlant(
+                _imageUrl = "https://nongsaro.go.kr/cms_contents/301/13336_MF_ATTACH_05.jpg",
+                _shortDescription = "덕구리난은 덕구리난과!",
+                _nickname = "덕구리난",
+                nextWaterDate = LocalDate.now().plusDays(3),
+                lastWaterDate = LocalDate.now(),
+                waterCycle = 3,
+                plantInformationId = plantInformation.getId,
+                memberId = 1L,
                 id = 1L,
             )
         )

--- a/src/test/kotlin/gdsc/plantory/util/DatabaseLoader.kt
+++ b/src/test/kotlin/gdsc/plantory/util/DatabaseLoader.kt
@@ -25,7 +25,7 @@ class DatabaseLoader(
     fun loadData() {
         log.info("[call DataLoader]")
 
-        memberRepository.save(Member("device_id"))
+        val member = memberRepository.save(Member("device-token", 1L))
 
         val plantInformation = plantInformationRepository.save(
             PlantInformation(
@@ -49,19 +49,30 @@ class DatabaseLoader(
             )
         )
 
-        companionPlantRepository.save(
-            CompanionPlant(
-                _imageUrl = "https://nongsaro.go.kr/cms_contents/301/13336_MF_ATTACH_05.jpg",
-                _shortDescription = "덕구리난은 덕구리난과!",
-                _nickname = "덕구리난",
-                nextWaterDate = LocalDate.now().plusDays(3),
-                lastWaterDate = LocalDate.now(),
-                waterCycle = 3,
-                plantInformationId = plantInformation.getId,
-                memberId = 1L,
-                id = 1L,
-            )
+        val companionPlant1 = CompanionPlant(
+            _imageUrl = "https://nongsaro.go.kr/cms_contents/301/13336_MF_ATTACH_05.jpg",
+            _shortDescription = "덕구리난은 덕구리난과!",
+            _nickname = "덕구리난1",
+            nextWaterDate = LocalDate.now().plusDays(3),
+            lastWaterDate = LocalDate.now(),
+            waterCycle = 3,
+            plantInformationId = plantInformation.getId,
+            memberId = member.getId,
+            id = 1L,
         )
+
+        val companionPlant2 = CompanionPlant(
+            _imageUrl = "https://nongsaro.go.kr/cms_contents/301/13336_MF_ATTACH_05.jpg",
+            _shortDescription = "덕구리난은 덕구리난과!",
+            _nickname = "덕구리난2",
+            nextWaterDate = LocalDate.now().plusDays(3),
+            lastWaterDate = LocalDate.now(),
+            waterCycle = 3,
+            plantInformationId = plantInformation.getId,
+            memberId = member.getId,
+            id = 2L,
+        )
+        companionPlantRepository.saveAll(listOf(companionPlant1, companionPlant2))
 
         log.info("[init complete DataLoader]")
     }


### PR DESCRIPTION
## TODO
- [x] 물주기 히스토리 구현
- [x] 분갈이 히스토리 구현
- [x] 조회 쿼리 수정
- [x] 쿼리 테스트 값 검증 수정

## 예상치 못한 지점
Kotlin은 기본적으로 상속이 막혀 있기에 Proxy생성에 고문받을 일이 많은....
allOpen에 기본생성자랑 다 만들어 줘도 안되기래 걍 pass
<img width="1664" alt="스크린샷 2024-01-15 오후 7 27 13" src="https://github.com/gdsc-konkuk/Plantory-Server/assets/60593969/7fe57126-ea7c-4f89-8301-d0c5da7e6d18">
