### PR TITLE
[Feat] palnt 삭제 API

### DIFF
--- a/src/main/kotlin/gdsc/plantory/plant/domain/CompanionPlantRepository.kt
+++ b/src/main/kotlin/gdsc/plantory/plant/domain/CompanionPlantRepository.kt
@@ -17,6 +17,7 @@ interface CompanionPlantRepository : JpaRepository<CompanionPlant, Long> {
 
     fun findAllByMemberId(memberId: Long): List<CompanionPlant>
     fun findByIdAndMemberId(id: Long, memberId: Long): CompanionPlant?
+    fun removeByIdAndMemberId(id: Long, memberId: Long)
 
     @Query(
         """

--- a/src/main/kotlin/gdsc/plantory/plant/presentation/PlantCommandApi.kt
+++ b/src/main/kotlin/gdsc/plantory/plant/presentation/PlantCommandApi.kt
@@ -40,7 +40,7 @@ class PlantCommandApi(
         @AccessDeviceToken deviceToken: String,
     ): ResponseEntity<Unit> {
         plantService.remove(request, deviceToken)
-        return ResponseEntity.ok().build()
+        return ResponseEntity.noContent().build()
     }
 
     @PostMapping("/histories", consumes = [MediaType.APPLICATION_JSON_VALUE])

--- a/src/main/kotlin/gdsc/plantory/plant/presentation/PlantCommandApi.kt
+++ b/src/main/kotlin/gdsc/plantory/plant/presentation/PlantCommandApi.kt
@@ -4,11 +4,13 @@ import BadRequestException
 import gdsc.plantory.common.support.AccessDeviceToken
 import gdsc.plantory.plant.domain.HistoryType
 import gdsc.plantory.plant.presentation.dto.CompanionPlantCreateRequest
+import gdsc.plantory.plant.presentation.dto.CompanionPlantDeleteRequest
 import gdsc.plantory.plant.presentation.dto.PlantRecordCreateRequest
 import gdsc.plantory.plant.presentation.dto.PlantHistoryRequest
 import gdsc.plantory.plant.service.PlantService
 import org.springframework.http.MediaType
 import org.springframework.http.ResponseEntity
+import org.springframework.web.bind.annotation.DeleteMapping
 import org.springframework.web.bind.annotation.PostMapping
 import org.springframework.web.bind.annotation.RequestBody
 import org.springframework.web.bind.annotation.RequestMapping
@@ -29,6 +31,15 @@ class PlantCommandApi(
         @AccessDeviceToken deviceToken: String,
     ): ResponseEntity<Unit> {
         plantService.create(request, image, deviceToken)
+        return ResponseEntity.ok().build()
+    }
+
+    @DeleteMapping(consumes = [MediaType.APPLICATION_JSON_VALUE])
+    fun remove(
+        @RequestBody request: CompanionPlantDeleteRequest,
+        @AccessDeviceToken deviceToken: String,
+    ): ResponseEntity<Unit> {
+        plantService.remove(request, deviceToken)
         return ResponseEntity.ok().build()
     }
 

--- a/src/main/kotlin/gdsc/plantory/plant/presentation/dto/CompanionPlantDeleteRequest.kt
+++ b/src/main/kotlin/gdsc/plantory/plant/presentation/dto/CompanionPlantDeleteRequest.kt
@@ -1,0 +1,5 @@
+package gdsc.plantory.plant.presentation.dto
+
+data class CompanionPlantDeleteRequest(
+    val companionPlantId: Long
+)

--- a/src/main/kotlin/gdsc/plantory/plant/service/PlantService.kt
+++ b/src/main/kotlin/gdsc/plantory/plant/service/PlantService.kt
@@ -9,6 +9,7 @@ import gdsc.plantory.plant.domain.findByIdAndMemberIdOrThrow
 import gdsc.plantory.plant.domain.findRecordByDateOrThrow
 import gdsc.plantory.plant.presentation.dto.PlantHistoriesLookupRequest
 import gdsc.plantory.plant.presentation.dto.CompanionPlantCreateRequest
+import gdsc.plantory.plant.presentation.dto.CompanionPlantDeleteRequest
 import gdsc.plantory.plant.presentation.dto.CompanionPlantsLookupResponse
 import gdsc.plantory.plant.presentation.dto.PlantRecordLookupRequest
 import gdsc.plantory.plant.presentation.dto.PlantRecordDto
@@ -37,6 +38,11 @@ class PlantService(
         val companionPlant = request.toEntity(imagePath, findMember.getId, findPlantInformation.getWaterCycle)
 
         companionPlantRepository.save(companionPlant)
+    }
+
+    fun remove(request: CompanionPlantDeleteRequest, deviceToken: String) {
+        val findMember = memberRepository.findByDeviceTokenOrThrow(deviceToken)
+        companionPlantRepository.removeByIdAndMemberId(request.companionPlantId, findMember.getId)
     }
 
     @Transactional(readOnly = true)

--- a/src/test/kotlin/gdsc/plantory/acceptance/CompanionPlantAcceptanceTest.kt
+++ b/src/test/kotlin/gdsc/plantory/acceptance/CompanionPlantAcceptanceTest.kt
@@ -6,6 +6,7 @@ import gdsc.plantory.acceptance.CompanionPlantStep.Companion.식물_조회_요�
 import gdsc.plantory.acceptance.CompanionPlantStep.Companion.데일리_기록_등록_요청
 import gdsc.plantory.acceptance.CompanionPlantStep.Companion.데일리_기록_조회_요청
 import gdsc.plantory.acceptance.CompanionPlantStep.Companion.데일리_기록_조회_응답_확인
+import gdsc.plantory.acceptance.CompanionPlantStep.Companion.반려_식물_삭제_요청
 import gdsc.plantory.acceptance.CompanionPlantStep.Companion.식물_히스토리_생성_요청
 import gdsc.plantory.acceptance.CompanionPlantStep.Companion.식물_조회_응답_확인
 import gdsc.plantory.acceptance.CompanionPlantStep.Companion.히스토리_조회_요청
@@ -16,6 +17,7 @@ import gdsc.plantory.fixture.테스터_디바이스_토큰
 import gdsc.plantory.fixture.테스트_식물정보_ID
 import gdsc.plantory.fixture.CompanionPlantFixture.generateCompanionPlantCreateRequest
 import gdsc.plantory.fixture.CompanionPlantFixture.generatePlantRecordCreateRequest
+import gdsc.plantory.plant.presentation.dto.CompanionPlantDeleteRequest
 import gdsc.plantory.plant.presentation.dto.PlantHistoryRequest
 import gdsc.plantory.plant.presentation.dto.PlantHistoriesLookupRequest
 import gdsc.plantory.plant.presentation.dto.PlantRecordLookupRequest
@@ -39,6 +41,18 @@ class CompanionPlantAcceptanceTest : AcceptanceTest() {
 
         // then
         응답_확인(식물_등록_요청_응답, HttpStatus.OK)
+    }
+
+    @Test
+    fun `반려식물 삭제`() {
+        // given
+        val 반려_식물_정보 = CompanionPlantDeleteRequest(기록있는_테스트식물_ID)
+
+        // when
+        val 식물_삭제_요청_응답 = 반려_식물_삭제_요청(반려_식물_정보, 테스터_디바이스_토큰)
+
+        // then
+        응답_확인(식물_삭제_요청_응답, HttpStatus.OK)
     }
 
     @Test

--- a/src/test/kotlin/gdsc/plantory/acceptance/CompanionPlantAcceptanceTest.kt
+++ b/src/test/kotlin/gdsc/plantory/acceptance/CompanionPlantAcceptanceTest.kt
@@ -52,7 +52,7 @@ class CompanionPlantAcceptanceTest : AcceptanceTest() {
         val 식물_삭제_요청_응답 = 반려_식물_삭제_요청(반려_식물_정보, 테스터_디바이스_토큰)
 
         // then
-        응답_확인(식물_삭제_요청_응답, HttpStatus.OK)
+        응답_확인(식물_삭제_요청_응답, HttpStatus.NO_CONTENT)
     }
 
     @Test

--- a/src/test/kotlin/gdsc/plantory/acceptance/CompanionPlantStep.kt
+++ b/src/test/kotlin/gdsc/plantory/acceptance/CompanionPlantStep.kt
@@ -1,6 +1,7 @@
 package gdsc.plantory.acceptance
 
 import gdsc.plantory.plant.presentation.dto.CompanionPlantCreateRequest
+import gdsc.plantory.plant.presentation.dto.CompanionPlantDeleteRequest
 import gdsc.plantory.plant.presentation.dto.PlantRecordCreateRequest
 import gdsc.plantory.plant.presentation.dto.PlantHistoryRequest
 import gdsc.plantory.plant.presentation.dto.PlantRecordLookupRequest
@@ -33,6 +34,24 @@ class CompanionPlantStep {
                 .log().all()
                 .`when`()
                 .post("/api/v1/plants")
+                .then()
+                .log().all()
+                .statusCode(HttpStatus.OK.value())
+                .extract()
+        }
+
+        fun 반려_식물_삭제_요청(
+            request: CompanionPlantDeleteRequest,
+            deviceToken: String,
+        ): ExtractableResponse<Response> {
+            return RestAssured
+                .given()
+                .contentType(MediaType.APPLICATION_JSON_VALUE)
+                .header("Device-Token", deviceToken)
+                .log().all()
+                .body(request)
+                .`when`()
+                .delete("/api/v1/plants")
                 .then()
                 .log().all()
                 .statusCode(HttpStatus.OK.value())

--- a/src/test/kotlin/gdsc/plantory/acceptance/CompanionPlantStep.kt
+++ b/src/test/kotlin/gdsc/plantory/acceptance/CompanionPlantStep.kt
@@ -54,7 +54,7 @@ class CompanionPlantStep {
                 .delete("/api/v1/plants")
                 .then()
                 .log().all()
-                .statusCode(HttpStatus.OK.value())
+                .statusCode(HttpStatus.NO_CONTENT.value())
                 .extract()
         }
 


### PR DESCRIPTION
### Todo

- [x] 반려식물 삭제 API close #23 

---

`DELETE`라 request body를 쓰지 않으려 했는데, 이전에 설정한 URL 구조면 불가피하다 생각했습니다.
아무래도 [없어야만 하는건 아니다](https://stackoverflow.com/questions/299628/is-an-entity-body-allowed-for-an-http-delete-request
)보니 그냥 req body로 설정했습니다.
