### PR TITLE
[Fix] ISSUE 탬플릿에 누락된 필수 필드(`about`) 추가

### DIFF
--- a/.github/ISSUE_TEMPLATE/1-FEAT.md
+++ b/.github/ISSUE_TEMPLATE/1-FEAT.md
@@ -1,5 +1,6 @@
 ---
 name: Feature Request
+about: 기능 구현 요청
 description: 새로운 기능 구현
 title: "[Feat]: ~~"
 labels: "🚀 기능 구현 🚀"


### PR DESCRIPTION
# 개요

ISSUE 탬플릿에 필수 필드인 about이 없어 github이 탬플릿을 인식하지 못하는 문제 해결

## Todo

- [x] 누락 필드 추가
