### PR TITLE
[Fix] ISSUE 탬플릿에 누락된 필수 필드(about) 추가 반영

### DIFF
--- a/.github/ISSUE_TEMPLATE/1-FEAT.md
+++ b/.github/ISSUE_TEMPLATE/1-FEAT.md
@@ -1,5 +1,6 @@
 ---
 name: Feature Request
+about: 기능 구현 요청
 description: 새로운 기능 구현
 title: "[Feat]: ~~"
 labels: "🚀 기능 구현 🚀"


### PR DESCRIPTION
# 개요

ISSUE 탬플릿에 필수 필드인 `about` 누락으로 github이 탬플릿을 인식하지 못하던 문제 해결
