### PR TITLE
[Feat] `RECORDING` hsitory 직접 추가 방지

### DIFF
--- a/src/main/kotlin/gdsc/plantory/plant/domain/CompanionPlant.kt
+++ b/src/main/kotlin/gdsc/plantory/plant/domain/CompanionPlant.kt
@@ -100,12 +100,11 @@ class CompanionPlant(
         }
 
         this.records.add(PlantRecord(imageUrl, comment, this))
+        this.saveRecordHistory(date)
     }
 
     fun saveHistory(historyType: HistoryType, date: LocalDate = LocalDate.now()) {
-        if (isNotCurrentDay(date)) {
-            throw IllegalArgumentException("물을 줄 날짜는 오늘 날짜여야 합니다.")
-        }
+        validateInput(historyType, date)
 
         if (historyType == HistoryType.WATER_CHANGE) {
             this.lastWaterDate = date
@@ -123,6 +122,22 @@ class CompanionPlant(
         require(!currentDate.isBefore(birthDate)) { "함께한 날은 음수가 될 수 없습니다. Date: $currentDate" }
 
         return ChronoUnit.DAYS.between(birthDate, currentDate).toInt() + 1
+    }
+
+    private fun validateInput(historyType: HistoryType, date: LocalDate) {
+        if (isRecordType(historyType)) {
+            throw IllegalArgumentException("데일리 기록은 히스토리 타입을 직접 추가할 수 없습니다.")
+        }
+
+        if (isNotCurrentDay(date)) {
+            throw IllegalArgumentException("물을 줄 날짜는 오늘 날짜여야 합니다.")
+        }
+    }
+
+    private fun isRecordType(historyType: HistoryType) = historyType == HistoryType.RECORDING
+
+    private fun saveRecordHistory(date: LocalDate) {
+        this.histories.add(PlantHistory(HistoryType.RECORDING, date, this))
     }
 
     private fun isNotCurrentDay(date: LocalDate) = !date.isEqual(LocalDate.now())

--- a/src/main/kotlin/gdsc/plantory/plant/service/PlantService.kt
+++ b/src/main/kotlin/gdsc/plantory/plant/service/PlantService.kt
@@ -60,6 +60,9 @@ class PlantService(
         val findMember = memberRepository.findByDeviceTokenOrThrow(deviceToken)
         val findCompanionPlant = companionPlantRepository.findByIdAndMemberIdOrThrow(plantId, findMember.getId)
 
+        if (historyType == HistoryType.RECORDING)
+            throw IllegalArgumentException("데일리 기록 히스토리는 직접 추가할 수 없습니다.")
+
         findCompanionPlant.saveHistory(historyType)
     }
 

--- a/src/main/kotlin/gdsc/plantory/plant/service/PlantService.kt
+++ b/src/main/kotlin/gdsc/plantory/plant/service/PlantService.kt
@@ -59,10 +59,6 @@ class PlantService(
     fun createPlantHistory(plantId: Long, deviceToken: String, historyType: HistoryType) {
         val findMember = memberRepository.findByDeviceTokenOrThrow(deviceToken)
         val findCompanionPlant = companionPlantRepository.findByIdAndMemberIdOrThrow(plantId, findMember.getId)
-
-        if (historyType == HistoryType.RECORDING)
-            throw IllegalArgumentException("데일리 기록 히스토리는 직접 추가할 수 없습니다.")
-
         findCompanionPlant.saveHistory(historyType)
     }
 
@@ -97,7 +93,6 @@ class PlantService(
         // TODO : Cloud 환경으로 이전 후 제거, 로컬 사진 저장 테스트 용도
         val baseUrl = "https://nongsaro.go.kr/"
         findCompanionPlant.saveRecord(request.comment, baseUrl + imagePath)
-        findCompanionPlant.saveHistory(HistoryType.RECORDING)
     }
 
     @Transactional(readOnly = true)

--- a/src/test/kotlin/gdsc/plantory/plant/domain/CompanionPlantTest.kt
+++ b/src/test/kotlin/gdsc/plantory/plant/domain/CompanionPlantTest.kt
@@ -31,6 +31,23 @@ class CompanionPlantTest {
     }
 
     @Test
+    fun `반려식물에게 레코드 타입의 히스토리를 직접 저장하려는 경우 예외 발생`() {
+        val waterCycle = 7L
+        val lastWaterDate = LocalDate.now()
+        val nextWaterDate = lastWaterDate.plusDays(waterCycle)
+        val companionPlant = CompanionPlant(
+            "https://nongsaro.go.kr/cms_contents/301/14687_MF_ATTACH_01.jpg",
+            "나의 아기 선인장", "shine", nextWaterDate, lastWaterDate, waterCycle.toInt()
+        )
+
+        assertThatThrownBy {
+            companionPlant.saveHistory(HistoryType.RECORDING, LocalDate.now())
+        }
+            .isInstanceOf(IllegalArgumentException::class.java)
+            .hasMessageContaining("데일리 기록은 히스토리 타입을 직접 추가할 수 없습니다.")
+    }
+
+    @Test
     fun `물 준 주기가 맞지 않으면 예외 발생`() {
         val waterCycle = 7L
         val lastWaterDate = LocalDate.now()

--- a/src/test/kotlin/gdsc/plantory/plant/service/PlantServiceTest.kt
+++ b/src/test/kotlin/gdsc/plantory/plant/service/PlantServiceTest.kt
@@ -1,5 +1,7 @@
 package gdsc.plantory.plant.service
 
+import gdsc.plantory.fixture.기록없는_테스트식물_ID
+import gdsc.plantory.fixture.테스터_디바이스_토큰
 import gdsc.plantory.plant.domain.CompanionPlant
 import gdsc.plantory.plant.domain.CompanionPlantRepository
 import gdsc.plantory.plant.domain.HistoryType
@@ -7,6 +9,7 @@ import gdsc.plantory.plantInformation.domain.PlantInformation
 import gdsc.plantory.plantInformation.domain.PlantInformationRepository
 import gdsc.plantory.util.AcceptanceTest
 import jakarta.persistence.EntityManager
+import org.assertj.core.api.Assertions.assertThatThrownBy
 import org.assertj.core.api.Assertions.assertThat
 import org.junit.jupiter.api.Assertions.assertAll
 import org.junit.jupiter.api.DisplayName
@@ -23,6 +26,16 @@ class PlantServiceTest(
     @Autowired val entityManager: EntityManager,
     @Autowired val plantInformationRepository: PlantInformationRepository,
 ) : AcceptanceTest() {
+
+    @Test
+    fun `데일리 기록 히스토리는 직접 추가할 수 없다`() {
+        // when, then
+        assertThatThrownBy {
+            plantService.createPlantHistory(기록없는_테스트식물_ID, 테스터_디바이스_토큰, HistoryType.RECORDING)
+        }
+            .isInstanceOf(IllegalArgumentException::class.java)
+            .hasMessageContaining("데일리 기록 히스토리는 직접 추가할 수 없습니다.")
+    }
 
     @Test
     fun `사용자는 식물의 데일리 기록을 조회하여 사진, 본문, 물준유무를 확인할 수 있다`() {

--- a/src/test/kotlin/gdsc/plantory/plant/service/PlantServiceTest.kt
+++ b/src/test/kotlin/gdsc/plantory/plant/service/PlantServiceTest.kt
@@ -9,8 +9,8 @@ import gdsc.plantory.plantInformation.domain.PlantInformation
 import gdsc.plantory.plantInformation.domain.PlantInformationRepository
 import gdsc.plantory.util.AcceptanceTest
 import jakarta.persistence.EntityManager
-import org.assertj.core.api.Assertions.assertThatThrownBy
 import org.assertj.core.api.Assertions.assertThat
+import org.assertj.core.api.Assertions.assertThatThrownBy
 import org.junit.jupiter.api.Assertions.assertAll
 import org.junit.jupiter.api.DisplayName
 import org.junit.jupiter.api.Test
@@ -34,7 +34,7 @@ class PlantServiceTest(
             plantService.createPlantHistory(기록없는_테스트식물_ID, 테스터_디바이스_토큰, HistoryType.RECORDING)
         }
             .isInstanceOf(IllegalArgumentException::class.java)
-            .hasMessageContaining("데일리 기록 히스토리는 직접 추가할 수 없습니다.")
+            .hasMessageContaining("데일리 기록은 히스토리 타입을 직접 추가할 수 없습니다.")
     }
 
     @Test
@@ -73,7 +73,6 @@ class PlantServiceTest(
             memberId = 1L,
         )
         companionPlant.saveRecord("test-record", "https://test.com", today)
-        companionPlant.saveHistory(HistoryType.RECORDING, today)
         companionPlant.saveHistory(HistoryType.WATER_CHANGE, today)
         val savedPlant = companionPlantRepository.save(companionPlant)
 
@@ -129,7 +128,6 @@ class PlantServiceTest(
         )
         val today = LocalDate.now()
         companionPlant.saveRecord("test-record", "https://test.com", today)
-        companionPlant.saveHistory(HistoryType.RECORDING, today)
         companionPlant.saveHistory(HistoryType.POT_CHANGE, today)
         val savedPlant = companionPlantRepository.save(companionPlant)
 

--- a/src/test/kotlin/gdsc/plantory/util/DatabaseLoader.kt
+++ b/src/test/kotlin/gdsc/plantory/util/DatabaseLoader.kt
@@ -31,7 +31,6 @@ class DatabaseLoader(
         val testCompanionPlantHasNoHistories = CompanionPlantFixture.generateTestCompanionPlantHasNoHistories(2L)
 
         testCompanionPlantWillHaveHistories.saveRecord("test-record", "https://test.com")
-        testCompanionPlantWillHaveHistories.saveHistory(HistoryType.RECORDING)
         testCompanionPlantWillHaveHistories.saveHistory(HistoryType.POT_CHANGE)
         testCompanionPlantWillHaveHistories.saveHistory(HistoryType.WATER_CHANGE)
 


### PR DESCRIPTION
# 개요

히스토리 추가 API를 통해 데일리 기록 히스토리 추가를 방지 (close #33)

## Todo

- [x] `PlantService` 테스트 작성
- [x] `PlantService.createHistory`가 `RECORDING` 직접 등록 방지하도록 변경

## 웃픈(?) 이야기

데일리 기록 히스토리 직접 추가는 곁가지고, 물줬을때 날짜 갱신이 메인인데, 이거 이미 구현되어있던 기능이네요
착각했던... ㅠ

![image](https://github.com/gdsc-konkuk/Plantory-Server/assets/33625132/1335e6d9-3d15-4d5d-937f-3496c365228b)

---

### 등록 전 확인

- [x] 모든 test가 pass했나요?
- [x] 모든 code가 well-formatted인가요?
- [x] commit message는 직관적이었을까요?
- [x] 삭제해야 할, 주석처리 된 코드는 없을까요?
