### PR TITLE
[Refactor] 테스트 Fixture 및 상수 정리

### DIFF
--- a/src/main/kotlin/gdsc/plantory/plant/presentation/dto/PlantHistoryDto.kt
+++ b/src/main/kotlin/gdsc/plantory/plant/presentation/dto/PlantHistoryDto.kt
@@ -1,7 +1,7 @@
 package gdsc.plantory.plant.presentation.dto
 
-import gdsc.plantory.plant.domain.PlantHistory
 import gdsc.plantory.plant.domain.HistoryType
+import gdsc.plantory.plant.domain.PlantHistory
 import java.time.LocalDate
 
 data class PlantHistoryDto(

--- a/src/test/kotlin/gdsc/plantory/acceptance/CompanionPlantAcceptanceTest.kt
+++ b/src/test/kotlin/gdsc/plantory/acceptance/CompanionPlantAcceptanceTest.kt
@@ -1,21 +1,18 @@
 package gdsc.plantory.acceptance
 
 import gdsc.plantory.acceptance.CommonStep.Companion.응답_확인
-import gdsc.plantory.acceptance.CompanionPlantStep.Companion.반려_식물_등록_요청
-import gdsc.plantory.acceptance.CompanionPlantStep.Companion.식물_조회_요청
 import gdsc.plantory.acceptance.CompanionPlantStep.Companion.데일리_기록_등록_요청
 import gdsc.plantory.acceptance.CompanionPlantStep.Companion.데일리_기록_조회_요청
 import gdsc.plantory.acceptance.CompanionPlantStep.Companion.데일리_기록_조회_응답_확인
+import gdsc.plantory.acceptance.CompanionPlantStep.Companion.반려_식물_등록_요청
 import gdsc.plantory.acceptance.CompanionPlantStep.Companion.반려_식물_삭제_요청
-import gdsc.plantory.acceptance.CompanionPlantStep.Companion.식물_히스토리_생성_요청
+import gdsc.plantory.acceptance.CompanionPlantStep.Companion.식물_조회_요청
 import gdsc.plantory.acceptance.CompanionPlantStep.Companion.식물_조회_응답_확인
+import gdsc.plantory.acceptance.CompanionPlantStep.Companion.식물_히스토리_생성_요청
 import gdsc.plantory.acceptance.CompanionPlantStep.Companion.히스토리_조회_요청
 import gdsc.plantory.acceptance.CompanionPlantStep.Companion.히스토리_조회_응답_확인
-import gdsc.plantory.fixture.기록없는_테스트식물_ID
-import gdsc.plantory.fixture.기록있는_테스트식물_ID
-import gdsc.plantory.fixture.테스터_디바이스_토큰
-import gdsc.plantory.fixture.테스트_식물정보_ID
 import gdsc.plantory.fixture.CompanionPlantFixture.generateCompanionPlantCreateRequest
+import gdsc.plantory.fixture.테스터_디바이스_토큰
 import gdsc.plantory.plant.presentation.dto.PlantHistoryRequest
 import gdsc.plantory.plant.presentation.dto.PlantRecordCreateRequest
 import gdsc.plantory.util.AcceptanceTest
@@ -31,7 +28,7 @@ class CompanionPlantAcceptanceTest : AcceptanceTest() {
     @Test
     fun `반려식물 등록`() {
         // given
-        val 반려_식물_정보 = generateCompanionPlantCreateRequest(테스트_식물정보_ID)
+        val 반려_식물_정보 = generateCompanionPlantCreateRequest(1L)
 
         // when
         val 식물_등록_요청_응답 = 반려_식물_등록_요청(반려_식물_정보, 테스터_디바이스_토큰)
@@ -43,7 +40,7 @@ class CompanionPlantAcceptanceTest : AcceptanceTest() {
     @Test
     fun `반려식물 삭제`() {
         // when
-        val 식물_삭제_요청_응답 = 반려_식물_삭제_요청(기록있는_테스트식물_ID, 테스터_디바이스_토큰)
+        val 식물_삭제_요청_응답 = 반려_식물_삭제_요청(1L, 테스터_디바이스_토큰)
 
         // then
         응답_확인(식물_삭제_요청_응답, HttpStatus.NO_CONTENT)
@@ -55,7 +52,7 @@ class CompanionPlantAcceptanceTest : AcceptanceTest() {
         val 물줌_기록 = PlantHistoryRequest("WATER_CHANGE")
 
         // when
-        val 식물_히스토리_생성_응답 = 식물_히스토리_생성_요청(기록없는_테스트식물_ID, 물줌_기록, 테스터_디바이스_토큰)
+        val 식물_히스토리_생성_응답 = 식물_히스토리_생성_요청(2L, 물줌_기록, 테스터_디바이스_토큰)
 
         // then
         응답_확인(식물_히스토리_생성_응답, HttpStatus.OK)
@@ -76,7 +73,7 @@ class CompanionPlantAcceptanceTest : AcceptanceTest() {
         val 데일리_기록_정보 = PlantRecordCreateRequest("오늘도 즐거운 하루~!")
 
         // when
-        val 데일리_기록_등록_요청_응답 = 데일리_기록_등록_요청(기록없는_테스트식물_ID, 데일리_기록_정보, 테스터_디바이스_토큰)
+        val 데일리_기록_등록_요청_응답 = 데일리_기록_등록_요청(2L, 데일리_기록_정보, 테스터_디바이스_토큰)
 
         // then
         응답_확인(데일리_기록_등록_요청_응답, HttpStatus.OK)
@@ -90,15 +87,11 @@ class CompanionPlantAcceptanceTest : AcceptanceTest() {
     @Test
     fun `반려식물 데일리 기록 중복 등록`() {
         // given
-        데일리_기록_등록_요청(
-            기록없는_테스트식물_ID, PlantRecordCreateRequest("오늘도 즐거운 하루~!"), 테스터_디바이스_토큰
-        )
+        데일리_기록_등록_요청(2L, PlantRecordCreateRequest("오늘도 즐거운 하루~!"), 테스터_디바이스_토큰)
 
         // when
         val 데일리_기록_등록_요청_응답 =
-            데일리_기록_등록_요청(
-                기록없는_테스트식물_ID, PlantRecordCreateRequest("오늘도 즐거운 하루~!"), 테스터_디바이스_토큰
-            )
+            데일리_기록_등록_요청(2L, PlantRecordCreateRequest("오늘도 즐거운 하루~!"), 테스터_디바이스_토큰)
 
         // then
         응답_확인(데일리_기록_등록_요청_응답, HttpStatus.CONFLICT)
@@ -107,7 +100,7 @@ class CompanionPlantAcceptanceTest : AcceptanceTest() {
     @Test
     fun `반려식물 데일리 기록 조회`() {
         // when
-        val 데일리_기록_조회_요청_응답 = 데일리_기록_조회_요청(기록있는_테스트식물_ID, LocalDate.now(), 테스터_디바이스_토큰)
+        val 데일리_기록_조회_요청_응답 = 데일리_기록_조회_요청(1L, LocalDate.now(), 테스터_디바이스_토큰)
 
         // then
         데일리_기록_조회_응답_확인(데일리_기록_조회_요청_응답)
@@ -116,7 +109,7 @@ class CompanionPlantAcceptanceTest : AcceptanceTest() {
     @Test
     fun `반려식물 히스토리 조회`() {
         // when
-        val 히스토리_조회_요청_응답 = 히스토리_조회_요청(기록있는_테스트식물_ID, YearMonth.parse("2024-01"), 테스터_디바이스_토큰)
+        val 히스토리_조회_요청_응답 = 히스토리_조회_요청(1L, YearMonth.parse("2024-01"), 테스터_디바이스_토큰)
 
         // then
         히스토리_조회_응답_확인(히스토리_조회_요청_응답)

--- a/src/test/kotlin/gdsc/plantory/fixture/CompanionPlantFixture.kt
+++ b/src/test/kotlin/gdsc/plantory/fixture/CompanionPlantFixture.kt
@@ -4,60 +4,29 @@ import gdsc.plantory.plant.domain.CompanionPlant
 import gdsc.plantory.plant.presentation.dto.CompanionPlantCreateRequest
 import java.time.LocalDate
 
-private var _기록없는_테스트식물_ID = 0L
-val 기록없는_테스트식물_ID
-    get() = _기록없는_테스트식물_ID
-
-private var _기록있는_테스트식물_ID = 0L
-val 기록있는_테스트식물_ID
-    get() = _기록있는_테스트식물_ID
-
-
 object CompanionPlantFixture {
 
-    val 덕구리난: CompanionPlant = CompanionPlant(
-        _imageUrl = "https://nongsaro.go.kr/cms_contents/301/13336_MF_ATTACH_05.jpg",
-        _shortDescription = "덕구리난은 덕구리난과!",
-        _nickname = "덕구리1",
-        birthDate = LocalDate.of(2024, 1, 1),
-        nextWaterDate = LocalDate.of(2024, 1, 10),
-        lastWaterDate = LocalDate.of(2024, 1, 7),
-        waterCycle = 3,
-        plantInformationId = 테스트_식물정보_ID,
-        memberId = 테스터_ID,
-    )
-
-    fun generateTestCompanionPlantHasNoHistories(id: Long): CompanionPlant {
-        _기록없는_테스트식물_ID = id
-
+    fun generateCompanionPlant(
+        memberId: Long = 0L,
+        plantInformationId: Long = 0L,
+        imageUrl: String = "https://nongsaro.go.kr/cms_contents/301/13336_MF_ATTACH_05.jpg",
+        shortDescription: String = "덕구리난은 덕구리난과!",
+        nickname: String = "테스트 식물",
+        nextWaterDate: LocalDate = LocalDate.of(2024, 1, 10),
+        lastWaterDate: LocalDate = LocalDate.of(2024, 1, 7),
+        waterCycle: Int = 3,
+        birthDate: LocalDate = LocalDate.of(2024, 1, 1),
+    ): CompanionPlant {
         return CompanionPlant(
-            _imageUrl = "https://nongsaro.go.kr/cms_contents/301/13336_MF_ATTACH_05.jpg",
-            _shortDescription = "덕구리난은 덕구리난과!",
-            _nickname = "히스토리 없는 테스트식물",
-            birthDate = LocalDate.of(2024, 1, 1),
-            nextWaterDate = LocalDate.of(2024, 1, 10),
-            lastWaterDate = LocalDate.of(2024, 1, 7),
-            waterCycle = 3,
-            plantInformationId = 테스트_식물정보_ID,
-            memberId = 테스터_ID,
-            id = id
-        )
-    }
-
-    fun generateTestCompanionPlantWillHaveHistories(id: Long): CompanionPlant {
-        _기록있는_테스트식물_ID = id
-
-        return CompanionPlant(
-            _imageUrl = "https://nongsaro.go.kr/cms_contents/301/13336_MF_ATTACH_05.jpg",
-            _shortDescription = "덕구리난은 덕구리난과!",
-            _nickname = "히스토리 있는 테스트식물",
-            birthDate = LocalDate.of(2024, 1, 1),
-            nextWaterDate = LocalDate.of(2024, 1, 10),
-            lastWaterDate = LocalDate.of(2024, 1, 7),
-            waterCycle = 3,
-            plantInformationId = 테스트_식물정보_ID,
-            memberId = 테스터_ID,
-            id = id
+            _imageUrl = imageUrl,
+            _shortDescription = shortDescription,
+            _nickname = nickname,
+            nextWaterDate = nextWaterDate,
+            lastWaterDate = lastWaterDate,
+            waterCycle = waterCycle,
+            birthDate = birthDate,
+            memberId = memberId,
+            plantInformationId = plantInformationId,
         )
     }
 

--- a/src/test/kotlin/gdsc/plantory/fixture/MemberFixture.kt
+++ b/src/test/kotlin/gdsc/plantory/fixture/MemberFixture.kt
@@ -2,20 +2,11 @@ package gdsc.plantory.fixture
 
 import gdsc.plantory.member.domain.Member
 
-private var _테스터_ID = 0L
-val 테스터_ID: Long
-    get() = _테스터_ID
-
-const val 테스터_디바이스_토큰 = "device-token"
+const val 테스터_디바이스_토큰 = "tester-token"
 
 object MemberFixture {
 
-    fun generateTestMember(id: Long): Member {
-        _테스터_ID = id
-
-        return Member(
-            deviceToken = 테스터_디바이스_토큰,
-            id = id
-        )
+    fun generateMember(deviceToken: String = "device-token"): Member {
+        return Member(deviceToken = deviceToken)
     }
 }

--- a/src/test/kotlin/gdsc/plantory/fixture/PlantInformationFixture.kt
+++ b/src/test/kotlin/gdsc/plantory/fixture/PlantInformationFixture.kt
@@ -2,33 +2,43 @@ package gdsc.plantory.fixture
 
 import gdsc.plantory.plantInformation.domain.PlantInformation
 
-private var _테스트_식물정보_ID = 0L
-val 테스트_식물정보_ID: Long
-    get() = _테스트_식물정보_ID
-
 object PlantInformationFixture {
 
-    fun generateTestPlantInformation(id: Long): PlantInformation {
-        _테스트_식물정보_ID = id
-
+    fun generatePlantInformation(
+        imageUrl: String = "https://nongsaro.go.kr/cms_contents/301/13336_MF_ATTACH_05.jpg",
+        species: String = "덕구리난",
+        familyName: String = "백합과",
+        requireTemp: String = "21~25℃",
+        minimumTemp: String = "13℃ 이상",
+        waterCycleSpring: Int = 4,
+        waterCycleSummer: Int = 3,
+        waterCycleAutumn: Int = 4,
+        waterCycleWinter: Int = 4,
+        smell: String = "거의 없음",
+        manageLevel: String = "초보자",
+        growSpeed: String = "느림",
+        requireHumidity: String = "40% 미만",
+        postingPlace: String = "거실 창측 (실내깊이 150~300cm),발코니 내측 (실내깊이 50~150cm),발코니 창측 (실내깊이 0~50cm)",
+        poison: String = "없음",
+        specialManageInfo: String = "적절한 환기가 필요함, 여름동안 햇볕이 잘드는 위치에 배치하는 것이 좋음.",
+    ): PlantInformation {
         return PlantInformation(
-            _species = "덕구리난",
-            _imageUrl = "https://nongsaro.go.kr/cms_contents/301/13336_MF_ATTACH_05.jpg",
-            _familyName = "백합과",
-            smell = "거의 없음",
-            poison = "없음",
-            manageLevel = "초보자",
-            growSpeed = "느림",
-            _requireTemp = "21~25℃",
-            _minimumTemp = "13℃ 이상",
-            requireHumidity = "40% 미만",
-            postingPlace = "거실 창측 (실내깊이 150~300cm),발코니 내측 (실내깊이 50~150cm),발코니 창측 (실내깊이 0~50cm)",
-            specialManageInfo = "적절한 환기가 필요함, 여름동안 햇볕이 잘드는 위치에 배치하는 것이 좋음.",
-            _waterCycleSpring = 4,
-            _waterCycleSummer = 3,
-            _waterCycleAutumn = 4,
-            _waterCycleWinter = 4,
-            id = id,
+            _imageUrl = imageUrl,
+            _species = species,
+            _familyName = familyName,
+            _requireTemp = requireTemp,
+            _minimumTemp = minimumTemp,
+            _waterCycleSpring = waterCycleSpring,
+            _waterCycleSummer = waterCycleSummer,
+            _waterCycleAutumn = waterCycleAutumn,
+            _waterCycleWinter = waterCycleWinter,
+            smell = smell,
+            manageLevel = manageLevel,
+            growSpeed = growSpeed,
+            requireHumidity = requireHumidity,
+            postingPlace = postingPlace,
+            poison = poison,
+            specialManageInfo = specialManageInfo,
         )
     }
 }

--- a/src/test/kotlin/gdsc/plantory/plant/domain/CompanionPlantRepositoryTest.kt
+++ b/src/test/kotlin/gdsc/plantory/plant/domain/CompanionPlantRepositoryTest.kt
@@ -1,6 +1,7 @@
 package gdsc.plantory.plant.domain
 
-import gdsc.plantory.member.domain.Member
+import gdsc.plantory.fixture.CompanionPlantFixture.generateCompanionPlant
+import gdsc.plantory.fixture.MemberFixture.generateMember
 import gdsc.plantory.member.domain.MemberRepository
 import gdsc.plantory.util.AcceptanceTest
 import org.assertj.core.api.Assertions.assertThat
@@ -19,7 +20,7 @@ class CompanionPlantRepositoryTest(
     @Test
     fun `물주는 날짜가 된 반려식물의 별칭과 해당 유저의 deviceToken을 조회한다`() {
         // given
-        val member = Member("shine")
+        val member = generateMember(deviceToken = "shine")
         val savedMember = memberRepository.save(member)
         val memberId = savedMember.getId
 
@@ -50,15 +51,12 @@ class CompanionPlantRepositoryTest(
             )
     }
 
-    private fun createCompanionPlantByLastWaterDate(nextWaterDate: LocalDate, memberId: Long) = CompanionPlant(
-        _imageUrl = "https://nongsaro.go.kr/cms_contents/301/13336_MF_ATTACH_05.jpg",
-        _shortDescription = "덕구리난은 덕구리난과!",
-        _nickname = nextWaterDate.toString(),
-        birthDate = LocalDate.of(2024, 1, 1),
-        nextWaterDate = nextWaterDate,
-        lastWaterDate = LocalDate.of(2024, 1, 4),
-        waterCycle = 3,
-        plantInformationId = 1L,
-        memberId = memberId,
-    )
+    private fun createCompanionPlantByLastWaterDate(nextWaterDate: LocalDate, memberId: Long) =
+        generateCompanionPlant(
+            memberId = memberId,
+            nickname = nextWaterDate.toString(),
+            nextWaterDate = nextWaterDate,
+            lastWaterDate = nextWaterDate.minusDays(5),
+            waterCycle = 5
+        )
 }

--- a/src/test/kotlin/gdsc/plantory/plant/service/PlantServiceTest.kt
+++ b/src/test/kotlin/gdsc/plantory/plant/service/PlantServiceTest.kt
@@ -1,16 +1,14 @@
 package gdsc.plantory.plant.service
 
-import gdsc.plantory.fixture.기록없는_테스트식물_ID
+import gdsc.plantory.fixture.CompanionPlantFixture.generateCompanionPlant
+import gdsc.plantory.fixture.PlantInformationFixture.generatePlantInformation
 import gdsc.plantory.fixture.테스터_디바이스_토큰
-import gdsc.plantory.plant.domain.CompanionPlant
 import gdsc.plantory.plant.domain.CompanionPlantRepository
 import gdsc.plantory.plant.domain.HistoryType
-import gdsc.plantory.plantInformation.domain.PlantInformation
 import gdsc.plantory.plantInformation.domain.PlantInformationRepository
 import gdsc.plantory.util.AcceptanceTest
 import jakarta.persistence.EntityManager
 import org.assertj.core.api.Assertions.assertThat
-import org.assertj.core.api.Assertions.assertThatThrownBy
 import org.junit.jupiter.api.Assertions.assertAll
 import org.junit.jupiter.api.DisplayName
 import org.junit.jupiter.api.Test
@@ -28,50 +26,13 @@ class PlantServiceTest(
 ) : AcceptanceTest() {
 
     @Test
-    fun `데일리 기록 히스토리는 직접 추가할 수 없다`() {
-        // when, then
-        assertThatThrownBy {
-            plantService.createPlantHistory(기록없는_테스트식물_ID, 테스터_디바이스_토큰, HistoryType.RECORDING)
-        }
-            .isInstanceOf(IllegalArgumentException::class.java)
-            .hasMessageContaining("데일리 기록은 히스토리 타입을 직접 추가할 수 없습니다.")
-    }
-
-    @Test
     fun `사용자는 식물의 데일리 기록을 조회하여 사진, 본문, 물준유무를 확인할 수 있다`() {
         // given
-        val plantInformation = PlantInformation(
-            _species = "덕구리난",
-            _imageUrl = "https://nongsaro.go.kr/cms_contents/301/13336_MF_ATTACH_05.jpg",
-            _familyName = "백합과",
-            smell = "거의 없음",
-            poison = "없음",
-            manageLevel = "초보자",
-            growSpeed = "느림",
-            _requireTemp = "21~25℃",
-            _minimumTemp = "13℃ 이상",
-            requireHumidity = "40% 미만",
-            postingPlace = "거실 창측 (실내깊이 150~300cm),발코니 내측 (실내깊이 50~150cm),발코니 창측 (실내깊이 0~50cm)",
-            specialManageInfo = "적절한 환기가 필요함, 여름동안 햇볕이 잘드는 위치에 배치하는 것이 좋음.",
-            _waterCycleSpring = 4,
-            _waterCycleSummer = 3,
-            _waterCycleAutumn = 4,
-            _waterCycleWinter = 4,
-        )
+        val plantInformation = generatePlantInformation()
         val savedPlantInformation = plantInformationRepository.save(plantInformation)
 
         val today = LocalDate.now()
-        val companionPlant = CompanionPlant(
-            _imageUrl = "https://nongsaro.go.kr/cms_contents/301/13336_MF_ATTACH_05.jpg",
-            _shortDescription = "덕구리난은 덕구리난과!",
-            _nickname = "shine",
-            birthDate = LocalDate.of(2024, 1, 1),
-            nextWaterDate = today,
-            lastWaterDate = LocalDate.of(2024, 1, 23),
-            waterCycle = 3,
-            plantInformationId = savedPlantInformation.getId,
-            memberId = 1L,
-        )
+        val companionPlant = generateCompanionPlant(memberId = 1L, plantInformationId = savedPlantInformation.getId)
         companionPlant.saveRecord("test-record", "https://test.com", today)
         companionPlant.saveHistory(HistoryType.WATER_CHANGE, today)
         val savedPlant = companionPlantRepository.save(companionPlant)
@@ -81,7 +42,7 @@ class PlantServiceTest(
 
         // when
         val result = plantService.lookupPlantRecordOfDate(
-            savedPlant.getId, today, "device-token"
+            savedPlant.getId, today, 테스터_디바이스_토큰
         )
 
         // then
@@ -95,37 +56,10 @@ class PlantServiceTest(
     @Test
     fun `사용자는 식물의 데일리 기록을 조회했을때 물을 주지 않았던 경우 기록에 물주는 표시가 비어있다`() {
         // given
-        val plantInformation = PlantInformation(
-            _species = "덕구리난",
-            _imageUrl = "https://nongsaro.go.kr/cms_contents/301/13336_MF_ATTACH_05.jpg",
-            _familyName = "백합과",
-            smell = "거의 없음",
-            poison = "없음",
-            manageLevel = "초보자",
-            growSpeed = "느림",
-            _requireTemp = "21~25℃",
-            _minimumTemp = "13℃ 이상",
-            requireHumidity = "40% 미만",
-            postingPlace = "거실 창측 (실내깊이 150~300cm),발코니 내측 (실내깊이 50~150cm),발코니 창측 (실내깊이 0~50cm)",
-            specialManageInfo = "적절한 환기가 필요함, 여름동안 햇볕이 잘드는 위치에 배치하는 것이 좋음.",
-            _waterCycleSpring = 4,
-            _waterCycleSummer = 3,
-            _waterCycleAutumn = 4,
-            _waterCycleWinter = 4,
-        )
+        val plantInformation = generatePlantInformation()
         val savedPlantInformation = plantInformationRepository.save(plantInformation)
 
-        val companionPlant = CompanionPlant(
-            _imageUrl = "https://nongsaro.go.kr/cms_contents/301/13336_MF_ATTACH_05.jpg",
-            _shortDescription = "덕구리난은 덕구리난과!",
-            _nickname = "shine",
-            birthDate = LocalDate.of(2024, 1, 1),
-            nextWaterDate = LocalDate.of(2024, 1, 25),
-            lastWaterDate = LocalDate.of(2024, 1, 23),
-            waterCycle = 3,
-            plantInformationId = savedPlantInformation.getId,
-            memberId = 1L,
-        )
+        val companionPlant = generateCompanionPlant(memberId = 1L, plantInformationId = savedPlantInformation.getId)
         val today = LocalDate.now()
         companionPlant.saveRecord("test-record", "https://test.com", today)
         companionPlant.saveHistory(HistoryType.POT_CHANGE, today)
@@ -136,7 +70,7 @@ class PlantServiceTest(
 
         // when
         val result = plantService.lookupPlantRecordOfDate(
-            savedPlant.getId, today, "device-token"
+            savedPlant.getId, today, 테스터_디바이스_토큰
         )
 
         // then

--- a/src/test/kotlin/gdsc/plantory/plantInformation/domain/PlantInformationTest.kt
+++ b/src/test/kotlin/gdsc/plantory/plantInformation/domain/PlantInformationTest.kt
@@ -1,5 +1,6 @@
 package gdsc.plantory.plantInformation.domain
 
+import gdsc.plantory.fixture.PlantInformationFixture.generatePlantInformation
 import org.assertj.core.api.Assertions.assertThatCode
 import org.junit.jupiter.api.DisplayName
 import org.junit.jupiter.api.Test
@@ -28,14 +29,7 @@ class PlantInformationTest {
     @CsvSource(value = ["'',Cactaceae; Juss.", "Cactaceae,''", "'',''"])
     fun `Species가 공백이라면 예외를 반환`(species: String, familyName: String) {
         assertThrows<IllegalArgumentException> {
-            PlantInformation(
-                "https://nongsaro.go.kr/cms_contents/301/14687_MF_ATTACH_01.jpg",
-                species, familyName,
-                "15 ~ 20", "5",
-                5, 5, 4, 3,
-                "earthy", "caution", "slow", "40%",
-                "veranda",
-            )
+            generatePlantInformation(species = species, familyName = familyName)
         }
     }
 
@@ -43,14 +37,7 @@ class PlantInformationTest {
     @CsvSource(value = ["'',5", "15 ~ 20,''", "'',''"])
     fun `Temperature가 공백이라면 예외를 반환`(requireTemp: String, minimumTemp: String) {
         assertThrows<IllegalArgumentException> {
-            PlantInformation(
-                "https://nongsaro.go.kr/cms_contents/301/14687_MF_ATTACH_01.jpg",
-                "Cactaceae", "Cactaceae; Juss.",
-                requireTemp, minimumTemp,
-                5, 5, 4, 3,
-                "earthy", "caution", "slow", "40%",
-                "veranda",
-            )
+            generatePlantInformation(requireTemp = requireTemp, minimumTemp = minimumTemp)
         }
     }
 
@@ -60,13 +47,11 @@ class PlantInformationTest {
         waterCycleSpring: Int, waterCycleSummer: Int, waterCycleAutumn: Int, waterCycleWinter: Int
     ) {
         assertThrows<IllegalArgumentException> {
-            PlantInformation(
-                "https://nongsaro.go.kr/cms_contents/301/14687_MF_ATTACH_01.jpg",
-                "Cactaceae", "Cactaceae; Juss.",
-                "15 ~ 20", "5",
-                waterCycleSpring, waterCycleSummer, waterCycleAutumn, waterCycleWinter,
-                "earthy", "caution", "slow", "40%",
-                "veranda",
+            generatePlantInformation(
+                waterCycleSpring = waterCycleSpring,
+                waterCycleSummer = waterCycleSummer,
+                waterCycleAutumn = waterCycleAutumn,
+                waterCycleWinter = waterCycleWinter
             )
         }
     }

--- a/src/test/kotlin/gdsc/plantory/util/DatabaseLoader.kt
+++ b/src/test/kotlin/gdsc/plantory/util/DatabaseLoader.kt
@@ -1,8 +1,9 @@
 package gdsc.plantory.util
 
-import gdsc.plantory.fixture.CompanionPlantFixture
-import gdsc.plantory.fixture.MemberFixture
-import gdsc.plantory.fixture.PlantInformationFixture
+import gdsc.plantory.fixture.CompanionPlantFixture.generateCompanionPlant
+import gdsc.plantory.fixture.MemberFixture.generateMember
+import gdsc.plantory.fixture.PlantInformationFixture.generatePlantInformation
+import gdsc.plantory.fixture.테스터_디바이스_토큰
 import gdsc.plantory.member.domain.MemberRepository
 import gdsc.plantory.plant.domain.CompanionPlantRepository
 import gdsc.plantory.plant.domain.HistoryType
@@ -25,18 +26,26 @@ class DatabaseLoader(
     fun loadData() {
         log.info("[call DataLoader]")
 
-        val testMember = MemberFixture.generateTestMember(1L)
-        val testPlantInformation = PlantInformationFixture.generateTestPlantInformation(1L)
-        val testCompanionPlantWillHaveHistories = CompanionPlantFixture.generateTestCompanionPlantWillHaveHistories(1L)
-        val testCompanionPlantHasNoHistories = CompanionPlantFixture.generateTestCompanionPlantHasNoHistories(2L)
+        val testMember = generateMember(deviceToken = 테스터_디바이스_토큰)
+        val savedTestMember = memberRepository.save(testMember)
 
-        testCompanionPlantWillHaveHistories.saveRecord("test-record", "https://test.com")
-        testCompanionPlantWillHaveHistories.saveHistory(HistoryType.POT_CHANGE)
-        testCompanionPlantWillHaveHistories.saveHistory(HistoryType.WATER_CHANGE)
+        val testPlantInformation = generatePlantInformation()
+        val savedTestPlantInformation = plantInformationRepository.save(testPlantInformation)
 
-        memberRepository.save(testMember)
-        plantInformationRepository.save(testPlantInformation)
-        companionPlantRepository.saveAll(listOf(testCompanionPlantWillHaveHistories, testCompanionPlantHasNoHistories))
+        val testCompanionPlantHasHistories = generateCompanionPlant(
+            memberId = savedTestMember.getId,
+            plantInformationId = savedTestPlantInformation.getId,
+        )
+        testCompanionPlantHasHistories.saveRecord("test-record", "https://test.com")
+        testCompanionPlantHasHistories.saveHistory(HistoryType.POT_CHANGE)
+        testCompanionPlantHasHistories.saveHistory(HistoryType.WATER_CHANGE)
+        val savedTestCompanionPlantHasHistories = companionPlantRepository.save(testCompanionPlantHasHistories)
+
+        val testCompanionPlantHasNoHistories = generateCompanionPlant(
+            memberId = savedTestMember.getId,
+            plantInformationId = savedTestPlantInformation.getId,
+        )
+        val savedTestCompanionPlantHasNoHistories = companionPlantRepository.save(testCompanionPlantHasNoHistories)
 
         log.info("[init complete DataLoader]")
     }


### PR DESCRIPTION
# 개요

지금까지 테스트에서 활용할 다양한 Object를 생성하는 방법은 제각각이었습니다. 인수테스트에서는 Database Loader에서 생성한 Object를 조회, 유닛테스트(도메인)에서는 명시적으로 생성자를 통한 생성하는 **경향**이 있었습니다. 

제가 느끼던 가장 큰 문제는 **인수테스트에서 기존에 삽입된 Entity를 조회할 때, 리터럴을 사용하고 있어서 Entity 간 구별이 어렵다**는 부분이었습니다. 이에 [refactoring을 통해 상수화](https://github.com/gdsc-konkuk/Plantory-Server/pull/20/commits/c828a745deac5d9b20e36a4a284b43b1f3e4982f)를 진행했지만, JPA 동작 이해도 부족과 Fixture와 Loader의 역할 분리를 고려하다 보니 이도저도 아니게 되어 오히려 처음보다 관리하기 어려운 코드가 되었습니다.

이번 PR에서는 이전에 진행되었던 refactoring을 고쳐 결과적으로 나은 testability를 확보하고자 합니다.  (close #34)

결론적으로, Fixture에 새로 정의한 `generator`를 적극 활용하는 방안으로 작성했습니다. 이유는 다음과 같습니다.

1. Object 생성 방법의 통일 - 아래와 같이, 이미 유닛(도메인)테스트에서도 Fixture를 활용하고 있었습니다.
```kt
    @Test
    fun `물을 주면 다음에 물을 주어야 할 날짜와 마지막으로 물 준 날짜 변경`() {
        // given
        val companionPlant: CompanionPlant = CompanionPlantFixture.덕구리난
       ...
    }
```
2. 가독성 향상 - 테스트에서 확인하고자 하는 사항에 집중
```kt
    // before
    @Test
    fun `식물 별칭이 너무 길 경우 예외가 발생`() {
        // when, then
        assertThatThrownBy {
            CompanionPlant(
              "https://nongsaro.go.kr/cms_contents/301/14687_MF_ATTACH_01.jpg",
              tooLongDescription, "shine", LocalDate.now().plusDays(7), LocalDate.now(),
              7, LocalDate.of(2023, 1, 1)
            )
        }
            .isInstanceOf(IllegalArgumentException::class.java)
            .hasMessageContaining("\"nickName\"은 16자를 초과할 수 없습니다.")
    }
```
```kt
    // after
    @Test
    fun `식물 별칭이 너무 길 경우 예외가 발생`() {
        // when, then
        assertThatThrownBy {
            generateCompanionPlant(nickname = tooLongNickName)
        }
            .isInstanceOf(IllegalArgumentException::class.java)
            .hasMessageContaining("\"nickName\"은 16자를 초과할 수 없습니다.")
    }
```

## Todo

- [x] Fixture 정리
- [x] DatabaseLoader 정리
- [x] imports ordering

## 논의가 필요한 사항

### Test Entity ID 정의 위치

현재 수정한 코드에서는 ID 상수화를 모두 제거하여 `1L`, `2L`과 같은 리터럴로 롤백해둔 상태입니다. 이렇게 한 이유는, [기존에 진행되었던 피드백](https://github.com/gdsc-konkuk/Plantory-Server/pull/20#discussion_r1454634719)을 유지하면서 상수화를 하는 좋은 방법을 생각해내지 못했기 때문입니다.

- Test Entity의 ID는 Fixture에서 결정할 수 없습니다. (`@GeneratedValue(strategy = GenerationType.IDENTITY)`)
- Test Entity의 ID를 결정짓는 객체는 `DatabaseLoader`입니다.

그래서 다음의 2가지를 생각해 보았습니다.

1. Fixture에 ID `변수`를 설정, Database Loader가 Update
2. 미리 저장해둔 상수 없이, `Acceptance/CommonStep`에 repository를 연결하여 `테스트_식물_ID()`와 같은 method의 형태로 조회하여 사용

1번 방법은 `public` 변수를 설정하는 위험을 감수해서는 안 된다고 생각했고, 2번 방법은 배보다 배꼽이 더 커지는 상황으로 생각해 적용하지 않았습니다.

때문에 저는 **`Test Entity ID`를 결정짓는것은 결국 `DatabaseLoader`이므로 해당 파일에 상수를 정의**하던가, 아니면 현 상황처럼 **상수화를 포기하고 리터럴로 사용**해야 한다고 결론내렸습니다만... 분명 무언가 더 좋은 방법이 있지는 않았을까 생각합니다.

현재 서비스와 리포지토리처럼 통합 테스트가 늘어가는 가운데, Test Entity 식별을 리터럴로 하는것은 언젠가 분명 부담되는 순간이 오리라고 생각합니다. 앞으로도 이 문제를 해결하기 위해 고민해보겠지만, 혹시 당장 생각나는 방법이 있으실지 궁금하네요

---

### 등록 전 확인

- [x] 모든 code가 well-formatted인가요?
- [x] commit message는 직관적이었을까요?
- [x] 삭제해야 할, 주석처리 된 코드는 없을까요?
